### PR TITLE
remove verbose from DDL model

### DIFF
--- a/ddlora-gfcpsstats11.dms
+++ b/ddlora-gfcpsstats11.dms
@@ -26,9 +26,9 @@ VALUES(
 \
 $DATATYPES NUMERIC,NUMERIC,NUMERIC,NUMERIC,CHARACTER
 4,2,0,0,$long
-gfcpsstats11.ps_stats(p_ownname=>[DBNAME],p_tabname=>[TBNAME],p_verbose=>TRUE);
+gfcpsstats11.ps_stats(p_ownname=>[DBNAME],p_tabname=>[TBNAME]);
 //
 5,2,0,0,$long
-gfcpsstats11.ps_stats(p_ownname=>[DBNAME],p_tabname=>[TBNAME],p_verbose=>TRUE);
+gfcpsstats11.ps_stats(p_ownname=>[DBNAME],p_tabname=>[TBNAME]);
 //
 /


### PR DESCRIPTION
Verbose option makes ps_stats write message to PeopleSoft message log,
but this causes problems from PT8.55.